### PR TITLE
Refactor/회원가입

### DIFF
--- a/be/src/main/java/com/project/popupmarket/controller/auth/OAuth2Controller.java
+++ b/be/src/main/java/com/project/popupmarket/controller/auth/OAuth2Controller.java
@@ -1,12 +1,14 @@
 package com.project.popupmarket.controller.auth;
 
+import com.project.popupmarket.dto.oauth.LoginResponse;
+import com.project.popupmarket.dto.oauth.OAuthSignupRequest;
 import com.project.popupmarket.dto.oauth.OAuthSignupRequiredResponse;
 import com.project.popupmarket.dto.token.CreateAccessTokenResponse;
-import com.project.popupmarket.entity.User;
-import com.project.popupmarket.service.token.TokenService;
-import com.project.popupmarket.service.user.UserService;
+import com.project.popupmarket.exception.ErrorResponse;
+import com.project.popupmarket.exception.oauth2.AuthenticationException;
+import com.project.popupmarket.exception.oauth2.SignupException;
+import com.project.popupmarket.service.oauth.OAuth2Service;
 import com.project.popupmarket.util.CookieUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,11 +16,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
-import java.util.Optional;
 
 import static com.project.popupmarket.config.jwt.AuthConstants.JWT_TOKEN_COOKIE_NAME;
 
@@ -26,53 +28,57 @@ import static com.project.popupmarket.config.jwt.AuthConstants.JWT_TOKEN_COOKIE_
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class OAuth2Controller {
-
-    private final TokenService tokenService;
-    private final UserService userService;
+    private final OAuth2Service oauth2Service;
 
     @PostMapping("/oauth2/callback")
     public ResponseEntity<?> oAuth2Callback(
             @AuthenticationPrincipal OAuth2User oAuth2User,
-            HttpServletRequest ignoredRequest,
             HttpServletResponse response) {
-
-        String email = oAuth2User.getAttribute("email");
-        if (email == null) {
-            return ResponseEntity.badRequest().body("이메일 정보를 찾을 수 없습니다.");
-        }
-
         try {
-            // 기존 회원인지 확인
-            Optional<User> userOptional = userService.findByEmail(email);
+            String email = oAuth2User.getAttribute("email");
+            LoginResponse loginResponse = oauth2Service.handleOAuth2Login(email);
 
-            if (userOptional.isEmpty()) {
-                // 기존 회원이 아닌 경우
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                                     .body(new OAuthSignupRequiredResponse(
-                                             "Google 로그인은 기존 회원만 사용할 수 있습니다. 회원가입을 먼저 진행해주세요.",
-                                             email));
+            if (loginResponse.isRequireSignup()) {
+                return ResponseEntity
+                        .status(HttpStatus.UNAUTHORIZED)
+                        .body(new OAuthSignupRequiredResponse("회원가입이 필요합니다.", loginResponse.getSignupUuid()));
             }
 
-            // 기존 회원인 경우 토큰 발급 및 처리
-            User user = userOptional.get();
-            String accessToken = tokenService.createAccessToken(user);
-            String refreshToken = tokenService.createRefreshToken(user);
+            CookieUtil.addCookie(response, JWT_TOKEN_COOKIE_NAME,
+                                 loginResponse.getRefreshToken(),
+                                 (int) Duration.ofDays(14).toSeconds());
 
-            // JWT 토큰을 쿠키에 저장
-            CookieUtil.addCookie(
-                    response,
-                    JWT_TOKEN_COOKIE_NAME,
-                    refreshToken,
-                    (int) Duration
-                            .ofDays(14).toSeconds()
-                                );
-
-            return ResponseEntity.ok()
-                                 .body(new CreateAccessTokenResponse(accessToken));
-
+            return ResponseEntity.ok(new CreateAccessTokenResponse(loginResponse.getAccessToken()));
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                                 .body("로그인 처리 중 오류가 발생했습니다.");
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse(e.getMessage(),
+                                            HttpStatus.INTERNAL_SERVER_ERROR.toString()));
+        }
+    }
+
+    @PostMapping("/oauth2/signup")
+    public ResponseEntity<?> oAuth2Signup(
+            @RequestBody OAuthSignupRequest request,
+            HttpServletResponse response) {
+        try {
+            LoginResponse loginResponse = oauth2Service.handleOAuth2Signup(request);
+
+            CookieUtil.addCookie(response, JWT_TOKEN_COOKIE_NAME,
+                                 loginResponse.getRefreshToken(),
+                                 (int) Duration.ofDays(14).toSeconds());
+
+            return ResponseEntity.ok(new CreateAccessTokenResponse(loginResponse.getAccessToken()));
+        } catch (AuthenticationException e) {
+            return ResponseEntity
+                    .status(e.getErrorCode().getStatus())
+                    .body(new ErrorResponse(e.getMessage(),
+                                            e.getErrorCode().getStatus().toString()));
+        } catch (SignupException e) {
+            return ResponseEntity
+                    .status(e.getErrorCode().getStatus())
+                    .body(new ErrorResponse(e.getMessage(),
+                                            e.getErrorCode().getStatus().toString()));
         }
     }
 }

--- a/be/src/main/java/com/project/popupmarket/controller/user/UserApiController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/user/UserApiController.java
@@ -29,23 +29,28 @@ public class UserApiController {
 
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody UserRegisterDto request, HttpServletResponse response) {
-        // 회원 저장 및 ID 반환
-        Long userId = userService.save(request);
+        try {
+            // 회원 저장 및 ID 반환
+            Long userId = userService.save(request);
 
-        // 저장된 회원 정보 조회
-        User user = userService.findById(userId);
+            // 저장된 회원 정보 조회
+            User user = userService.findById(userId);
 
-        // JWT 토큰 생성
-        String refreshToken = tokenService.createRefreshToken(user);
-        String accessToken = tokenService.createAccessToken(user);
+            // JWT 토큰 생성
+            String refreshToken = tokenService.createRefreshToken(user);
+            String accessToken = tokenService.createAccessToken(user);
 
 
-        // 쿠키에 리프레시 토큰 저장
-        CookieUtil.addCookie(response, JWT_TOKEN_COOKIE_NAME, refreshToken, (int) Duration
-                .ofDays(14)
-                .toSeconds());
+            // 쿠키에 리프레시 토큰 저장
+            CookieUtil.addCookie(response, JWT_TOKEN_COOKIE_NAME, refreshToken, (int) Duration
+                    .ofDays(14)
+                    .toSeconds());
 
-        return ResponseEntity.ok(new CreateAccessTokenResponse(accessToken));
+            return ResponseEntity.ok(new CreateAccessTokenResponse(accessToken));
+        } catch (Exception e) {
+            return ResponseEntity
+                    .badRequest()
+                    .body("회원가입에 실패했습니다.");
+        }
     }
-
 }

--- a/be/src/main/java/com/project/popupmarket/dto/oauth/LoginResponse.java
+++ b/be/src/main/java/com/project/popupmarket/dto/oauth/LoginResponse.java
@@ -1,0 +1,26 @@
+package com.project.popupmarket.dto.oauth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class LoginResponse {
+    private final String accessToken;
+    private final String refreshToken;
+    private final boolean requireSignup;
+    private final String signupUuid;
+
+    public static LoginResponse requireSignup(String uuid) {
+        return new LoginResponse(null, null, true, uuid);
+    }
+
+    public LoginResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.requireSignup = false;
+        this.signupUuid = null;
+    }
+}

--- a/be/src/main/java/com/project/popupmarket/dto/oauth/OAuthSignupRequest.java
+++ b/be/src/main/java/com/project/popupmarket/dto/oauth/OAuthSignupRequest.java
@@ -1,22 +1,15 @@
-package com.project.popupmarket.dto.user;
+package com.project.popupmarket.dto.oauth;
 
 import com.project.popupmarket.enums.Role;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter @Setter
-public class UserRegisterDto {
-    @NotEmpty(message = "이메일은 필수입니다")
-    @Email(message = "이메일 형식이 올바르지 않습니다")
-    private String email;
-
-    @NotEmpty(message = "비밀번호는 필수입니다")
-    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
-    private String password;
-
+@Getter
+@Setter
+public class OAuthSignupRequest {
+    @NotEmpty(message = "uuid는 필수입니다")
+    private String uuid;
     @NotEmpty(message = "이름은 필수입니다")
     private String name;
 

--- a/be/src/main/java/com/project/popupmarket/dto/oauth/OAuthSignupRequiredResponse.java
+++ b/be/src/main/java/com/project/popupmarket/dto/oauth/OAuthSignupRequiredResponse.java
@@ -1,9 +1,11 @@
 package com.project.popupmarket.dto.oauth;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public class OAuthSignupRequiredResponse {
     String message;
-    String email;
+    String uuid;
 }

--- a/be/src/main/java/com/project/popupmarket/entity/BusinessId.java
+++ b/be/src/main/java/com/project/popupmarket/entity/BusinessId.java
@@ -1,0 +1,29 @@
+package com.project.popupmarket.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "business_info")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BusinessId {
+    @Id
+    private Long userId;    // User의 id를 PK로 직접 사용
+
+    @Column(nullable = false)
+    private String businessId;  // 사업자 등록번호
+
+    @Builder
+    public BusinessId(Long userId, String businessId) {
+        this.userId = userId;
+        this.businessId = businessId;
+    }
+}
+

--- a/be/src/main/java/com/project/popupmarket/entity/User.java
+++ b/be/src/main/java/com/project/popupmarket/entity/User.java
@@ -25,7 +25,7 @@ public class User implements UserDetails {
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
-    @Column(name = "password")
+    @Column(name = "password", nullable = true)
     private String password;
 
     @Column(name = "name", nullable = false)
@@ -45,9 +45,6 @@ public class User implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Column(name = "business_id")
-    private String businessId;
-
     @Column(nullable = false)
     private LocalDateTime registeredAt;
 
@@ -57,14 +54,14 @@ public class User implements UserDetails {
     }
 
     @Builder
-    public User(String email, String password, String name, String brand, String tel) {
+    public User(String email, String password, String name, String brand, String tel, Role role, AuthProvider social) {
         this.email = email;
         this.password = password;
         this.name = name;
         this.brand = brand;
         this.tel = tel;
-        this.role = Role.CUSTOMER;
-        this.social = AuthProvider.GOOGLE;
+        this.role = role;
+        this.social = social;
     }
 
     public User update(String nickname) {

--- a/be/src/main/java/com/project/popupmarket/exception/ErrorCode.java
+++ b/be/src/main/java/com/project/popupmarket/exception/ErrorCode.java
@@ -10,8 +10,11 @@ public enum ErrorCode {
     // 에러코드 필요시 추가.
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     LAND_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 임대지입니다."),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
-
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+    UNAUTHORIZED_GOOGLE_REDIS(HttpStatus.UNAUTHORIZED, "구글 계정 인증이 만료되었습니다."),
+    SIGNUP_FAILED(HttpStatus.BAD_REQUEST, "회원가입에 실패하였습니다."),
+    GOOGLE_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "구글 인증에 실패했습니다."),
+    INVALID_OAUTH_STATE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth 상태입니다.");
     private final HttpStatus status;
     private final String message;
 }

--- a/be/src/main/java/com/project/popupmarket/exception/oauth2/AuthenticationException.java
+++ b/be/src/main/java/com/project/popupmarket/exception/oauth2/AuthenticationException.java
@@ -1,0 +1,14 @@
+package com.project.popupmarket.exception.oauth2;
+
+import com.project.popupmarket.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuthenticationException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public AuthenticationException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/be/src/main/java/com/project/popupmarket/exception/oauth2/SignupException.java
+++ b/be/src/main/java/com/project/popupmarket/exception/oauth2/SignupException.java
@@ -1,0 +1,14 @@
+package com.project.popupmarket.exception.oauth2;
+
+import com.project.popupmarket.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class SignupException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public SignupException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/be/src/main/java/com/project/popupmarket/repository/BusinessIdRepository.java
+++ b/be/src/main/java/com/project/popupmarket/repository/BusinessIdRepository.java
@@ -1,0 +1,7 @@
+package com.project.popupmarket.repository;
+
+import com.project.popupmarket.entity.BusinessId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BusinessIdRepository extends JpaRepository<BusinessId, Long> {
+}

--- a/be/src/main/java/com/project/popupmarket/repository/UserRepository.java
+++ b/be/src/main/java/com/project/popupmarket/repository/UserRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/be/src/main/java/com/project/popupmarket/service/oauth/OAuth2Service.java
+++ b/be/src/main/java/com/project/popupmarket/service/oauth/OAuth2Service.java
@@ -1,0 +1,77 @@
+package com.project.popupmarket.service.oauth;
+
+import com.project.popupmarket.dto.oauth.LoginResponse;
+import com.project.popupmarket.dto.oauth.OAuthSignupRequest;
+import com.project.popupmarket.entity.User;
+import com.project.popupmarket.enums.AuthProvider;
+import com.project.popupmarket.exception.ErrorCode;
+import com.project.popupmarket.exception.oauth2.AuthenticationException;
+import com.project.popupmarket.exception.oauth2.SignupException;
+import com.project.popupmarket.service.token.TokenService;
+import com.project.popupmarket.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2Service {
+    private static final long REDIS_TTL_MINUTES = 30;
+    private final TokenService tokenService;
+    private final UserService userService;
+    private final StringRedisTemplate stringTemplate;
+
+    // 구글 게정이 이미 가입되어 있는지 확인
+    public LoginResponse handleOAuth2Login(String email) {
+        Optional<User> userOptional = userService.findByEmail(email);
+
+        if (userOptional.isEmpty() || userOptional.get().getSocial() != AuthProvider.GOOGLE) {
+            String uuid = saveTemporaryUserData(email);
+            return LoginResponse.requireSignup(uuid);
+        }
+
+        return createLoginResponse(userOptional.get());
+    }
+
+    // 구글 로그인 회원가입 처리
+    public LoginResponse handleOAuth2Signup(OAuthSignupRequest request) {
+        String email = getEmailFromRedis(request.getUuid());
+        if (email == null) {
+            throw new AuthenticationException(ErrorCode.UNAUTHORIZED_GOOGLE_REDIS);
+        }
+
+        User user = userService.save(request, email)
+                               .orElseThrow(() -> new SignupException(ErrorCode.SIGNUP_FAILED));
+
+        stringTemplate.delete(AuthProvider.GOOGLE + request.getUuid());
+        return createLoginResponse(user);
+    }
+
+    // Redis에 구글 이메일 정보 임시 저장
+    private String saveTemporaryUserData(String email) {
+        String redisKey = AuthProvider.GOOGLE + email;
+        String uuid = UUID
+                .randomUUID().toString();
+        ValueOperations<String, String> ops = stringTemplate.opsForValue();
+        ops.set(redisKey, uuid, Duration.ofMinutes(REDIS_TTL_MINUTES));
+        return uuid;
+    }
+
+    // Redis에서 구글 이메일 정보 가져오기
+    private String getEmailFromRedis(String uuid) {
+        ValueOperations<String, String> ops = stringTemplate.opsForValue();
+        return ops.get(AuthProvider.GOOGLE + uuid);
+    }
+
+    // 로그인 응답 생성
+    private LoginResponse createLoginResponse(User user) {
+        String accessToken = tokenService.createAccessToken(user);
+        String refreshToken = tokenService.createRefreshToken(user);
+        return new LoginResponse(accessToken, refreshToken);
+    }
+}

--- a/be/src/main/java/com/project/popupmarket/service/oauth/OAuth2UserCustomService.java
+++ b/be/src/main/java/com/project/popupmarket/service/oauth/OAuth2UserCustomService.java
@@ -1,17 +1,38 @@
 package com.project.popupmarket.service.oauth;
 
+import com.project.popupmarket.dto.oauth.OAuthSignupRequest;
+import com.project.popupmarket.dto.user.UserRegisterDto;
+import com.project.popupmarket.entity.BusinessId;
+import com.project.popupmarket.entity.User;
+import com.project.popupmarket.enums.AuthProvider;
+import com.project.popupmarket.repository.BusinessIdRepository;
+import com.project.popupmarket.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Service
 public class OAuth2UserCustomService extends DefaultOAuth2UserService {
+    @Autowired
+    private StringRedisTemplate stringTemplate;
+    private final UserRepository userRepository;
+    private final BusinessIdRepository businessIdRepository;
+
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         return super.loadUser(userRequest);
     }
+
+
+
 }

--- a/be/src/main/java/com/project/popupmarket/service/user/UserService.java
+++ b/be/src/main/java/com/project/popupmarket/service/user/UserService.java
@@ -1,9 +1,13 @@
 package com.project.popupmarket.service.user;
 
 import com.project.popupmarket.dto.auth.LoginRequest;
+import com.project.popupmarket.dto.oauth.OAuthSignupRequest;
 import com.project.popupmarket.dto.user.UserRegisterDto;
 import com.project.popupmarket.dto.user.UserUpdateRequest;
+import com.project.popupmarket.entity.BusinessId;
 import com.project.popupmarket.entity.User;
+import com.project.popupmarket.enums.AuthProvider;
+import com.project.popupmarket.repository.BusinessIdRepository;
 import com.project.popupmarket.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -28,16 +32,18 @@ import java.util.UUID;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final BusinessIdRepository businessIdRepository;
     private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
     private final List<String> ALLOWED_EXTENSIONS = Arrays.asList(".jpg", ".jpeg", ".png", ".gif");
     private final long MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
     @Value("${app.upload-path}")
     private String uploadPath;
 
+    // 이메일로 회원가입 처리
     public Long save(UserRegisterDto dto) {
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
-
-        return userRepository
+        validateDuplicateEmail(dto.getEmail());
+        long userId = userRepository
                 .save(User
                               .builder()
                               .email(dto.getEmail())
@@ -45,8 +51,30 @@ public class UserService {
                               .brand(dto.getBrand())
                               .name(dto.getName())
                               .tel(dto.getTel())
+                              .role(dto.getRole())
+                              .social(AuthProvider.EMAIL)
                               .build())
                 .getId();
+        businessIdRepository.save(BusinessId.builder().userId(userId).businessId(dto.getBusinessId()).build());
+        return userId;
+    }
+    // 구글 로그인 회원가입 처리
+    public Optional<User> save(OAuthSignupRequest dto, String email) {
+        long userId = userRepository
+                .save(User
+                              .builder()
+                              .email(email)
+                              .brand(dto.getBrand())
+                              .name(dto.getName())
+                              .tel(dto.getTel())
+                              .role(dto.getRole())
+                              .social(AuthProvider.GOOGLE)
+                              .build())
+                .getId();
+
+        businessIdRepository.save(BusinessId
+                                          .builder().userId(userId).businessId(dto.getBusinessId()).build());
+        return userRepository.findById(userId);
     }
 
     public User findById(Long userId) {
@@ -176,5 +204,11 @@ public class UserService {
 
         // 3. 인증된 사용자 정보 반환 (SecurityContextHolder 설정 제거)
         return user;
+    }
+
+    private void validateDuplicateEmail(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
     }
 }

--- a/be/src/test/java/com/project/popupmarket/controller/auth/OAuth2ControllerTest.java
+++ b/be/src/test/java/com/project/popupmarket/controller/auth/OAuth2ControllerTest.java
@@ -1,0 +1,174 @@
+package com.project.popupmarket.controller.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.popupmarket.dto.oauth.LoginResponse;
+import com.project.popupmarket.dto.oauth.OAuthSignupRequest;
+import com.project.popupmarket.enums.Role;
+import com.project.popupmarket.exception.ErrorCode;
+import com.project.popupmarket.exception.oauth2.AuthenticationException;
+import com.project.popupmarket.service.oauth.OAuth2Service;
+import com.project.popupmarket.service.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.project.popupmarket.config.jwt.AuthConstants.JWT_TOKEN_COOKIE_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class OAuth2ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private OAuth2Service oauth2Service;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private StringRedisTemplate redisTemplate;
+
+    @MockBean
+    private ValueOperations<String, String> valueOperations;
+
+    private OAuth2User oauth2User;
+    private OAuth2AuthenticationToken authentication;
+
+    @BeforeEach
+    void setUp() {
+        // OAuth2User 설정
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", "test@example.com");
+        attributes.put("name", "Test User");
+
+        oauth2User = new DefaultOAuth2User(Collections.emptyList(), attributes, "email");
+
+        authentication = new OAuth2AuthenticationToken(oauth2User, Collections.emptyList(), "google");
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("OAuth2 콜백 - 신규 사용자 회원가입 필요")
+    void oauth2CallbackNewUserTest() throws Exception {
+        // given
+        String email = "test@example.com";
+        String uuid = "test-uuid";
+        given(oauth2Service.handleOAuth2Login(email)).willReturn(LoginResponse.requireSignup(uuid));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/oauth2/callback")
+                                .with(oauth2Login().oauth2User(oauth2User))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))  // Accept 헤더 추가
+               .andExpect(status().isUnauthorized())
+               .andExpect(jsonPath("$.message").value("회원가입이 필요합니다."))
+               .andExpect(jsonPath("$.uuid").value(uuid));
+    }
+
+    @Test
+    @DisplayName("OAuth2 콜백 - 기존 사용자 로그인 성공")
+    void oauth2CallbackExistingUserTest() throws Exception {
+        // given
+        String email = "test@example.com";
+        String accessToken = "test-access-token";
+        String refreshToken = "test-refresh-token";
+
+        given(oauth2Service.handleOAuth2Login(email)).willReturn(new LoginResponse(accessToken, refreshToken));
+
+        // when & then
+        mockMvc
+                .perform(post("/api/auth/oauth2/callback")
+                                 .with(oauth2Login().oauth2User(oauth2User))
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value(accessToken))
+                .andExpect(cookie().exists(JWT_TOKEN_COOKIE_NAME))
+                .andExpect(cookie().value(JWT_TOKEN_COOKIE_NAME, refreshToken));
+    }
+
+    @Test
+    @DisplayName("OAuth2 회원가입 - 성공")
+    void oauth2SignupSuccessTest() throws Exception {
+        // given
+        OAuthSignupRequest request = new OAuthSignupRequest();
+        request.setUuid("test-uuid");
+        request.setName("Test User");
+        request.setBrand("Test Brand");
+        request.setTel("010-1234-5678");
+        request.setBusinessId("123-45-67890");
+        request.setRole(Role.LANDLORD);
+
+        String accessToken = "test-access-token";
+        String refreshToken = "test-refresh-token";
+
+        given(oauth2Service.handleOAuth2Signup(any(OAuthSignupRequest.class))).willReturn(
+                new LoginResponse(accessToken, refreshToken));
+
+        // when & then
+        mockMvc
+                .perform(post("/api/auth/oauth2/signup")
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value(accessToken))
+                .andExpect(cookie().exists(JWT_TOKEN_COOKIE_NAME))
+                .andExpect(cookie().value(JWT_TOKEN_COOKIE_NAME, refreshToken));
+    }
+
+    @Test
+    @DisplayName("OAuth2 회원가입 - 실패 (Redis에서 이메일을 찾을 수 없음)")
+    void oauth2SignupFailureTest() throws Exception {
+        // given
+        OAuthSignupRequest request = new OAuthSignupRequest();
+        request.setUuid("invalid-uuid");
+        request.setName("Test User");
+        request.setBrand("Test Brand");
+        request.setTel("010-1234-5678");
+        request.setBusinessId("123-45-67890");
+        request.setRole(Role.LANDLORD);
+
+        given(oauth2Service.handleOAuth2Signup(any(OAuthSignupRequest.class))).willThrow(
+                new AuthenticationException(ErrorCode.UNAUTHORIZED_GOOGLE_REDIS));
+
+        // when & then
+        mockMvc
+                .perform(post("/api/auth/oauth2/signup")
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("구글 계정 인증이 만료되었습니다."));
+    }
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
회원가입 리팩토링
기존 : 유저 역할 고정. 또한 구글 소셜 로그인 시에 회원가입하는 과정과 이메일 회원가입 사용자가 동일한 방법으로 진행됨
수정 : 유저 역할을 선택 할 수 있도록 수정하였으며, 구글 로그인 시에는 회원이 존재하지 않는 경우 401 코드와 uuid를 클라이언트에 전달.
서버는 구글 이메일을 값으로 uuid를 키로 값을 레디시에 저장하고. 클라이언트는 uuid와 추가적인 사용자 정보를 받아 소셜 로그인 컨트롤러에 값을 전달하여 회원가입을 진행됨.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
