### PR TITLE
Feature/admin service

### DIFF
--- a/be/src/main/java/com/project/popupmarket/controller/admin/AdminController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/admin/AdminController.java
@@ -3,6 +3,7 @@ package com.project.popupmarket.controller.admin;
 //import com.project.popupmarket.dto.admin.AdminDashboardTO;
 import com.project.popupmarket.dto.admin.AdminDashboardSummaryTO;
 import com.project.popupmarket.dto.admin.AdminDashboardTO;
+import com.project.popupmarket.dto.admin.AdminPeriodAnalyticsTO;
 import com.project.popupmarket.dto.admin.AdminReceiptsDTO;
 import com.project.popupmarket.dto.land.RentalLandTO;
 import com.project.popupmarket.dto.popup.PopupTO;
@@ -12,6 +13,8 @@ import com.project.popupmarket.service.admin.AdminService;
 import com.project.popupmarket.service.land.RentalLandService;
 import com.project.popupmarket.service.popup.PopupService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -79,6 +82,19 @@ public class AdminController {
     @GetMapping("/dashboard")
     public ResponseEntity<AdminDashboardSummaryTO> getWeeklyDashboard() {
         return ResponseEntity.ok(adminService.getWeeklyDashboard());
+    }
+
+    @GetMapping("/analytics/daily")
+    public ResponseEntity<AdminPeriodAnalyticsTO> getDailyAnalytics(
+            @RequestParam(defaultValue = "7") int days
+    ) {
+        return ResponseEntity.ok(adminService.getDailyAnalytics(days - 1));
+    }
+    @GetMapping("/analytics/monthly")
+    public ResponseEntity<AdminPeriodAnalyticsTO> getMonthlyAnalytics(
+            @RequestParam(defaultValue = "6") int months
+    ) {
+        return ResponseEntity.ok(adminService.getMonthlyAnalytics(months - 1));
     }
 
     // [ Delete ] - 1 

--- a/be/src/main/java/com/project/popupmarket/controller/admin/AdminController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/admin/AdminController.java
@@ -12,10 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,6 +33,13 @@ public class AdminController {
     ) {
         Page<RentalLandTO> rentalLandTO = rentalLandService.findLandAdminByFilter(address, status, title, sorting, pageable);
         return ResponseEntity.ok(rentalLandTO);
+    }
+
+    @DeleteMapping("/land/{id}")
+    @Operation(summary = "개별 임대지 삭제")
+    public ResponseEntity<Void> deleteLand(@PathVariable Long id) {
+        rentalLandService.delete(id);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/receipts")

--- a/be/src/main/java/com/project/popupmarket/controller/admin/AdminController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/admin/AdminController.java
@@ -2,10 +2,12 @@ package com.project.popupmarket.controller.admin;
 
 import com.project.popupmarket.dto.admin.AdminReceiptsDTO;
 import com.project.popupmarket.dto.land.RentalLandTO;
+import com.project.popupmarket.dto.popup.PopupTO;
 import com.project.popupmarket.enums.ActivateStatus;
 import com.project.popupmarket.enums.ReservationStatus;
 import com.project.popupmarket.service.admin.AdminService;
 import com.project.popupmarket.service.land.RentalLandService;
+import com.project.popupmarket.service.popup.PopupService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
 
     private final RentalLandService rentalLandService;
+    private final PopupService popupService;
     private final AdminService adminService;
 
     @GetMapping("/lands")
@@ -39,6 +42,27 @@ public class AdminController {
     @Operation(summary = "개별 임대지 삭제")
     public ResponseEntity<Void> deleteLand(@PathVariable Long id) {
         rentalLandService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/popups")
+    @Operation(summary = "조건에 해당하는 팝업 리스트")
+    public ResponseEntity<Page<PopupTO>> getPopupsByFilter(
+            @RequestParam(required = false) String address,
+            @RequestParam(required = false) ActivateStatus status,
+            @RequestParam(required = false) String sorting,
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String type,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<PopupTO> popupTO = popupService.findPopupAdminByFilter(address, status, title, type, sorting, pageable);
+        return ResponseEntity.ok(popupTO);
+    }
+
+    @DeleteMapping("/popup/{id}")
+    @Operation(summary = "개별 임대지 삭제")
+    public ResponseEntity<Void> deletePopup(@PathVariable Long id) {
+        popupService.deletePopupById(id);
         return ResponseEntity.noContent().build();
     }
 

--- a/be/src/main/java/com/project/popupmarket/controller/admin/AdminController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/admin/AdminController.java
@@ -1,5 +1,8 @@
 package com.project.popupmarket.controller.admin;
 
+//import com.project.popupmarket.dto.admin.AdminDashboardTO;
+import com.project.popupmarket.dto.admin.AdminDashboardSummaryTO;
+import com.project.popupmarket.dto.admin.AdminDashboardTO;
 import com.project.popupmarket.dto.admin.AdminReceiptsDTO;
 import com.project.popupmarket.dto.land.RentalLandTO;
 import com.project.popupmarket.dto.popup.PopupTO;
@@ -16,6 +19,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
@@ -25,6 +30,8 @@ public class AdminController {
     private final PopupService popupService;
     private final AdminService adminService;
 
+    // [ READ ] - 1
+    // : 조건에 해당하는 임대지 리스트 불러오기
     @GetMapping("/lands")
     @Operation(summary = "조건에 해당하는 임대지 리스트")
     public ResponseEntity<Page<RentalLandTO>> getLandsByFilter(
@@ -38,13 +45,8 @@ public class AdminController {
         return ResponseEntity.ok(rentalLandTO);
     }
 
-    @DeleteMapping("/land/{id}")
-    @Operation(summary = "개별 임대지 삭제")
-    public ResponseEntity<Void> deleteLand(@PathVariable Long id) {
-        rentalLandService.delete(id);
-        return ResponseEntity.noContent().build();
-    }
-
+    // [ READ ] - 2
+    // : 조건에 해당하는 팝업 리스트 불러오기
     @GetMapping("/popups")
     @Operation(summary = "조건에 해당하는 팝업 리스트")
     public ResponseEntity<Page<PopupTO>> getPopupsByFilter(
@@ -59,13 +61,8 @@ public class AdminController {
         return ResponseEntity.ok(popupTO);
     }
 
-    @DeleteMapping("/popup/{id}")
-    @Operation(summary = "개별 임대지 삭제")
-    public ResponseEntity<Void> deletePopup(@PathVariable Long id) {
-        popupService.deletePopupById(id);
-        return ResponseEntity.noContent().build();
-    }
-
+    // [ READ ] - 3
+    // : 조건에 해당하는 거래 내역 관리 리스트 불러오기
     @GetMapping("/receipts")
     @Operation(summary = "조건에 해당하는 거래 내역 관리 리스트")
     public ResponseEntity<Page<AdminReceiptsDTO>> getReceiptsFilter(
@@ -76,4 +73,31 @@ public class AdminController {
         Page<AdminReceiptsDTO> adminReceiptsDTOPage = adminService.getAdminReceiptsInfo(status, sorting, pageable);
         return ResponseEntity.ok(adminReceiptsDTOPage);
     }
+
+    // [ READ ] - 4
+    // : 조건에 해당하는 메인 대시보드 불러오기
+    @GetMapping("/dashboard")
+    public ResponseEntity<AdminDashboardSummaryTO> getWeeklyDashboard() {
+        return ResponseEntity.ok(adminService.getWeeklyDashboard());
+    }
+
+    // [ Delete ] - 1 
+    // : id에 해당하는 개별 임대지 삭제
+    @DeleteMapping("/land/{id}")
+    @Operation(summary = "개별 임대지 삭제")
+    public ResponseEntity<Void> deleteLand(@PathVariable Long id) {
+        rentalLandService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // [ Delete ] - 2 
+    // : id에 해당하는 개별 팝업 삭제
+    @DeleteMapping("/popup/{id}")
+    @Operation(summary = "개별 팝업 삭제")
+    public ResponseEntity<Void> deletePopup(@PathVariable Long id) {
+        popupService.deletePopupById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    
 }

--- a/be/src/main/java/com/project/popupmarket/dto/admin/AdminDashboardSummaryTO.java
+++ b/be/src/main/java/com/project/popupmarket/dto/admin/AdminDashboardSummaryTO.java
@@ -1,0 +1,25 @@
+package com.project.popupmarket.dto.admin;
+
+import com.project.popupmarket.enums.ActivateStatus;
+import com.project.popupmarket.enums.Role;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminDashboardSummaryTO {
+    private List<AdminDashboardTO> dashboardList;  // 개별 거래 내역 리스트
+    private List<Object[]>  dailyCounts;  // 일일 거래량 요약 데이터
+    private List<Object[]> weeklyRegistered;
+    private Map<Role, Long> countUsersByRole;
+    private Map<ActivateStatus, Long> totalRentalLands;
+    private Map<ActivateStatus, Long> totalPopups;
+    private AdminMonthlyCountTO monthlyCount;
+}
+

--- a/be/src/main/java/com/project/popupmarket/dto/admin/AdminDashboardSummaryTO.java
+++ b/be/src/main/java/com/project/popupmarket/dto/admin/AdminDashboardSummaryTO.java
@@ -15,10 +15,10 @@ import java.util.Map;
 @AllArgsConstructor
 public class AdminDashboardSummaryTO {
     private List<AdminDashboardTO> dashboardList;  // 개별 거래 내역 리스트
-    private List<Object[]>  dailyCounts;  // 일일 거래량 요약 데이터
-    private List<Object[]> weeklyRegistered;
-    private Map<Role, Long> countUsersByRole;
-    private Map<ActivateStatus, Long> totalRentalLands;
+    private List<Map<String, Object>>  dailyCounts;  // 일일 거래량 요약 데이터
+    private List<Map<String, Object>> weeklyRegistered;
+    private Map<Role, Long> countUsers;
+    private Map<ActivateStatus, Long> totalLands;
     private Map<ActivateStatus, Long> totalPopups;
     private AdminMonthlyCountTO monthlyCount;
 }

--- a/be/src/main/java/com/project/popupmarket/dto/admin/AdminDashboardTO.java
+++ b/be/src/main/java/com/project/popupmarket/dto/admin/AdminDashboardTO.java
@@ -1,0 +1,16 @@
+package com.project.popupmarket.dto.admin;
+
+import com.project.popupmarket.dto.payment.ReceiptsManageTO;
+import lombok.*;
+
+
+@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminDashboardTO {
+    private ReceiptsManageTO receipts;
+    private String customer;
+    private String landlord;
+}

--- a/be/src/main/java/com/project/popupmarket/dto/admin/AdminDataAnalyticsTO.java
+++ b/be/src/main/java/com/project/popupmarket/dto/admin/AdminDataAnalyticsTO.java
@@ -1,0 +1,15 @@
+package com.project.popupmarket.dto.admin;
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminDataAnalyticsTO {
+    private List<String> labels;
+    private List<Long> data;
+}

--- a/be/src/main/java/com/project/popupmarket/dto/admin/AdminMonthlyCountTO.java
+++ b/be/src/main/java/com/project/popupmarket/dto/admin/AdminMonthlyCountTO.java
@@ -1,0 +1,17 @@
+package com.project.popupmarket.dto.admin;
+
+
+import lombok.*;
+
+@Data
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminMonthlyCountTO {
+    private Long monthlyCount;
+    private Long monthly;
+    private Long weekly;
+    private Long daily;
+}
+

--- a/be/src/main/java/com/project/popupmarket/dto/admin/AdminPeriodAnalyticsTO.java
+++ b/be/src/main/java/com/project/popupmarket/dto/admin/AdminPeriodAnalyticsTO.java
@@ -1,0 +1,19 @@
+package com.project.popupmarket.dto.admin;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.project.popupmarket.enums.ActivateStatus;
+import com.project.popupmarket.enums.Role;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminPeriodAnalyticsTO {
+    private List<Map<String, Object>> current;
+    private List<Map<String, Object>> prev;
+}

--- a/be/src/main/java/com/project/popupmarket/dto/admin/AdminPeriodAnalyticsTO.java
+++ b/be/src/main/java/com/project/popupmarket/dto/admin/AdminPeriodAnalyticsTO.java
@@ -1,8 +1,5 @@
 package com.project.popupmarket.dto.admin;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.project.popupmarket.enums.ActivateStatus;
-import com.project.popupmarket.enums.Role;
 import lombok.*;
 
 import java.util.List;
@@ -16,4 +13,5 @@ import java.util.Map;
 public class AdminPeriodAnalyticsTO {
     private List<Map<String, Object>> current;
     private List<Map<String, Object>> prev;
+    private AdminDataAnalyticsTO data;
 }

--- a/be/src/main/java/com/project/popupmarket/dto/payment/ReceiptsManageTO.java
+++ b/be/src/main/java/com/project/popupmarket/dto/payment/ReceiptsManageTO.java
@@ -2,18 +2,23 @@ package com.project.popupmarket.dto.payment;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.project.popupmarket.enums.ReservationStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ReceiptsManageTO {
     private String paymentKey;
     private BigDecimal amount;
-    private ReservationStatus reservationStatus;
+    private LocalDate start;
+    private LocalDate end;
+    private ReservationStatus status;
     private LocalDateTime reservedAt;
 }

--- a/be/src/main/java/com/project/popupmarket/repository/PopupJpaRepository.kt
+++ b/be/src/main/java/com/project/popupmarket/repository/PopupJpaRepository.kt
@@ -81,6 +81,13 @@ interface PopupJpaRepository : JpaRepository<Popup, Long> {
         pageable: Pageable?
     ): Page<Popup>
 
+    @Query("""
+    SELECT p.status, COUNT(p) 
+    FROM Popup p 
+    GROUP BY p.status"""
+    )
+    fun countPopupsByStatus(): List<Array<Any>>
+
     @Query("SELECT p.customerId FROM Popup p WHERE p.id = :id")
     fun findUserSeqById(@Param("id") id: Long): Long
 

--- a/be/src/main/java/com/project/popupmarket/repository/PopupJpaRepository.kt
+++ b/be/src/main/java/com/project/popupmarket/repository/PopupJpaRepository.kt
@@ -1,6 +1,8 @@
 package com.project.popupmarket.repository
 
 import com.project.popupmarket.entity.Popup
+import com.project.popupmarket.entity.RentalLand
+import com.project.popupmarket.enums.ActivateStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import org.springframework.data.domain.Page
@@ -59,6 +61,22 @@ interface PopupJpaRepository : JpaRepository<Popup, Long> {
         @Param("targetAgeGroup") targetAgeGroup: String?,
         @Param("startDate") startDate: LocalDate?,
         @Param("endDate") endDate: LocalDate?,
+        @Param("sorting") sorting: String?,
+        pageable: Pageable?
+    ): Page<Popup>
+
+    @Query(
+        ("SELECT p FROM Popup p "+
+                "WHERE (:address IS NULL OR p.address LIKE CONCAT('%', :address, '%')) " +
+                "AND (:title IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :title, '%'))) " +
+                "AND (:type IS NULL OR LOWER(p.type) LIKE LOWER(CONCAT('%', :type, '%'))) " +
+                "AND (:status IS NULL OR p.status = :status)")
+    )
+    fun findPopupAdminByFilter(
+        @Param("address") address: String?,
+        @Param("status") status: ActivateStatus?,
+        @Param("title") title: String?,
+        @Param("type") type: String?,
         @Param("sorting") sorting: String?,
         pageable: Pageable?
     ): Page<Popup>

--- a/be/src/main/java/com/project/popupmarket/repository/ReceiptsRepository.kt
+++ b/be/src/main/java/com/project/popupmarket/repository/ReceiptsRepository.kt
@@ -2,7 +2,44 @@ package com.project.popupmarket.repository
 
 import com.project.popupmarket.entity.Receipts
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
 
 @Repository
-interface ReceiptsRepository : JpaRepository<Receipts?, String?>, ReceiptsJDslRepository
+interface ReceiptsRepository : JpaRepository<Receipts?, String?>, ReceiptsJDslRepository{
+    @Query(
+        """SELECT r, customerUser.name, landlordUser.name FROM Receipts r 
+        JOIN User customerUser ON r.customerId = customerUser.id 
+        JOIN User landlordUser ON r.rentalLandId = landlordUser.id 
+        WHERE r.reservedAt BETWEEN :startDate AND :endDate"""
+    )
+    fun findDashboardsBetween(
+        @Param("startDate") startDate: LocalDateTime,
+        @Param("endDate") endDate: LocalDateTime
+    ): List<Array<Any>>
+
+    @Query("""
+    SELECT COALESCE(SUM(r.amount), 0) 
+    FROM Receipts r 
+    WHERE r.reservedAt BETWEEN :startDate AND :endDate
+    """)
+    fun findTotalAmountByBetween(
+        @Param("startDate") startDate: LocalDateTime,
+        @Param("endDate") endDate: LocalDateTime
+    ): Long
+
+    @Query("""
+    SELECT COUNT(r) 
+    FROM Receipts r 
+    WHERE r.reservedAt BETWEEN :startDate AND :endDate
+    """)
+    fun findTotalCountByBetween(
+        @Param("startDate") startDate: LocalDateTime,
+        @Param("endDate") endDate: LocalDateTime
+    ): Long
+
+
+}

--- a/be/src/main/java/com/project/popupmarket/repository/ReceiptsRepository.kt
+++ b/be/src/main/java/com/project/popupmarket/repository/ReceiptsRepository.kt
@@ -41,5 +41,30 @@ interface ReceiptsRepository : JpaRepository<Receipts?, String?>, ReceiptsJDslRe
         @Param("endDate") endDate: LocalDateTime
     ): Long
 
+    @Query(
+        """SELECT FUNCTION('DATE_FORMAT', r.reservedAt, '%m-%d'), SUM(r.amount)
+    FROM Receipts r
+    WHERE r.reservedAt BETWEEN :startDate AND :endDate
+    GROUP BY FUNCTION('DATE_FORMAT', r.reservedAt, '%m-%d')
+    ORDER BY FUNCTION('DATE_FORMAT', r.reservedAt, '%m-%d') ASC
+    """)
+    fun findDailySalesBetween(
+        @Param("startDate") startDate: LocalDateTime,
+        @Param("endDate") endDate: LocalDateTime
+    ): List<Array<Any>>
+
+    @Query(
+        """SELECT FUNCTION('DATE_FORMAT', r.reservedAt, '%m'), SUM(r.amount)
+       FROM Receipts r
+       WHERE r.reservedAt BETWEEN :startDate AND :endDate
+       GROUP BY FUNCTION('DATE_FORMAT', r.reservedAt, '%m')
+       ORDER BY FUNCTION('DATE_FORMAT', r.reservedAt, '%m') ASC
+    """
+    )
+    fun findMonthlySalesBetween(
+        @Param("startDate") startDate: LocalDateTime,
+        @Param("endDate") endDate: LocalDateTime
+    ): List<Array<Any>>
+
 
 }

--- a/be/src/main/java/com/project/popupmarket/repository/ReceiptsRepository.kt
+++ b/be/src/main/java/com/project/popupmarket/repository/ReceiptsRepository.kt
@@ -66,5 +66,18 @@ interface ReceiptsRepository : JpaRepository<Receipts?, String?>, ReceiptsJDslRe
         @Param("endDate") endDate: LocalDateTime
     ): List<Array<Any>>
 
+    @Query(
+        """SELECT rl.address, SUM(r.amount)
+        FROM Receipts r
+        JOIN RentalLand rl ON r.rentalLandId = rl.id
+        WHERE r.reservedAt BETWEEN :startDate AND :endDate
+        GROUP BY rl.address
+        ORDER BY SUM(r.amount) DESC
+    """)
+    fun findRevenueByAddress(
+        @Param("startDate") startDate: LocalDateTime,
+        @Param("endDate") endDate: LocalDateTime
+    ): List<Array<Any>>
+
 
 }

--- a/be/src/main/java/com/project/popupmarket/repository/RentalLandJpaRepository.kt
+++ b/be/src/main/java/com/project/popupmarket/repository/RentalLandJpaRepository.kt
@@ -87,6 +87,13 @@ interface RentalLandJpaRepository : JpaRepository<RentalLand, Long> {
         pageable: Pageable?
     ): Page<RentalLand>
 
+    @Query("""
+    SELECT rl.status, COUNT(rl) 
+    FROM RentalLand rl 
+    GROUP BY rl.status"""
+    )
+    fun countRentalLandsByStatus(): List<Array<Any>>
+
     @Modifying
     @Query("DELETE FROM RentalLand r WHERE r.id = :id")
     fun deleteRentalLandById(@Param("id") id: Long)

--- a/be/src/main/java/com/project/popupmarket/repository/UserRepository.java
+++ b/be/src/main/java/com/project/popupmarket/repository/UserRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,4 +18,22 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.id = :id")
     User findUserInfoById(@Param("id") Long id);
+
+    @Query("""
+    SELECT u.role, COUNT(u) 
+    FROM User u 
+    GROUP BY u.role
+    """)
+    List<Object[]> countUsersByRole();
+
+    @Query("""
+        SELECT FUNCTION('DATE_FORMAT', u.registeredAt, '%Y-%m-%d'), COUNT(u)
+        FROM User u 
+        WHERE u.registeredAt BETWEEN :startDate AND :endDate
+        GROUP BY FUNCTION('DATE_FORMAT', u.registeredAt, '%Y-%m-%d')"""
+    )
+    List<Object[]> findUsersByRegisteredAtBetween(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 }

--- a/be/src/main/java/com/project/popupmarket/repository/UserRepository.kt
+++ b/be/src/main/java/com/project/popupmarket/repository/UserRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface UserRepository : JpaRepository<User, Long> {
@@ -13,4 +14,26 @@ interface UserRepository : JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.id = :id")
     fun findUserInfoById(@Param("id") id: Long): User
+
+    @Query(
+        """
+        SELECT u.role, COUNT(u) 
+        FROM User u 
+        GROUP BY u.role
+    """
+    )
+    fun countUsersByRole(): List<Array<Any?>?>?
+
+    @Query(
+        """
+        SELECT FUNCTION('DATE_FORMAT', u.registeredAt, '%Y-%m-%d'), COUNT(u)
+        FROM User u 
+        WHERE u.registeredAt BETWEEN :startDate AND :endDate
+        GROUP BY FUNCTION('DATE_FORMAT', u.registeredAt, '%Y-%m-%d')
+        """
+    )
+    fun findUsersByRegisteredAtBetween(
+        @Param("startDate") startDate: LocalDateTime?,
+        @Param("endDate") endDate: LocalDateTime?,
+    ): List<Array<Any?>?>?
 }

--- a/be/src/main/java/com/project/popupmarket/service/admin/AdminService.java
+++ b/be/src/main/java/com/project/popupmarket/service/admin/AdminService.java
@@ -1,10 +1,7 @@
 package com.project.popupmarket.service.admin;
 
 //import com.project.popupmarket.dto.admin.AdminDashboardTO;
-import com.project.popupmarket.dto.admin.AdminDashboardSummaryTO;
-import com.project.popupmarket.dto.admin.AdminDashboardTO;
-import com.project.popupmarket.dto.admin.AdminMonthlyCountTO;
-import com.project.popupmarket.dto.admin.AdminReceiptsDTO;
+import com.project.popupmarket.dto.admin.*;
 import com.project.popupmarket.dto.land.RentalLandTO;
 import com.project.popupmarket.dto.payment.ReceiptsManageTO;
 import com.project.popupmarket.dto.user.UserDto;
@@ -21,8 +18,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -65,7 +67,7 @@ public class AdminService {
 
     public AdminDashboardSummaryTO getWeeklyDashboard(){
 
-        List<Object[]> dashboardData = receiptsRepository.findDashboardsBetween(LocalDateTime.now().minusDays(30), LocalDateTime.now());
+        List<Object[]> dashboardData = receiptsRepository.findDashboardsBetween(LocalDateTime.now().minusDays(6), LocalDateTime.now());
         List<AdminDashboardTO> dashboardList = dashboardData.stream()
                 .map(obj -> {
                     Receipts receipts = (Receipts) obj[0];  // Receipts 엔티티
@@ -101,16 +103,18 @@ public class AdminService {
                 ));
 
         // 모든 날짜를 포함하여 데이터 생성 (없는 날짜는 0)
-        List<Object[]> dailyCounts = lastWeekDates.stream()
-                .map(date -> new Object[]{date.toString(), transactionMap.getOrDefault(date, 0L)})
+        List<Map<String, Object>> dailyCounts = lastWeekDates.stream()
+                .map(date -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("date", date);
+                    map.put("count", transactionMap.getOrDefault(date, 0L));
+                    return map;
+                })
                 .toList();
-
-
-//        List<Object[]> weeklyRegistered = userRepository.findUsersByRegisteredAtBetween(LocalDateTime.now().minusDays(7),LocalDateTime.now());
 
         // DB에서 가져온 회원 등록 데이터
         List<Object[]> weeklyRegistered = userRepository.findUsersByRegisteredAtBetween(
-                LocalDateTime.now().minusDays(7), LocalDateTime.now()
+                LocalDateTime.now().minusDays(6), LocalDateTime.now()
         );
 
         // 데이터를 Map<LocalDate, Long> 형태로 변환
@@ -121,10 +125,14 @@ public class AdminService {
                 ));
 
         // 모든 날짜를 포함하여 결과 생성 (없는 날짜는 0)
-        List<Object[]> formattedWeeklyRegistered = lastWeekDates.stream()
-                .map(date -> new Object[]{date.toString(), registeredMap.getOrDefault(date, 0L)})
+        List<Map<String, Object>> formattedWeeklyRegistered = lastWeekDates.stream()
+                .map(date -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("date", date);
+                    map.put("count", registeredMap.getOrDefault(date, 0L));
+                    return map;
+                })
                 .toList();
-
 
         Map<Role, Long> countUsersByRoleMap = userRepository.countUsersByRole().stream()
                 .collect(Collectors.toMap(
@@ -151,18 +159,127 @@ public class AdminService {
                 .daily(receiptsRepository.findTotalAmountByBetween(LocalDateTime.now().minusDays(1),LocalDateTime.now()))
                 .build();
 
-        AdminDashboardSummaryTO dashboardSummaryTO = AdminDashboardSummaryTO.builder()
+        return AdminDashboardSummaryTO.builder()
                 .dashboardList(dashboardList)
                 .dailyCounts(dailyCounts)
                 .weeklyRegistered(formattedWeeklyRegistered)
-                .countUsersByRole(countUsersByRoleMap)
-                .totalRentalLands(totalRentalLandsMap)
+                .countUsers(countUsersByRoleMap)
+                .totalLands(totalRentalLandsMap)
                 .totalPopups(totalPopupsMap)
                 .monthlyCount(adminMonthlyCountTO)
                 .build();
-
-        return dashboardSummaryTO;
     }
 
+    public AdminPeriodAnalyticsTO getDailyAnalytics(int days){
+        // 현재 주간 데이터 날짜 범위 설정
+        LocalDateTime endDate = LocalDateTime.now();
+        LocalDateTime startDate = endDate.minusDays(days);
+        List<Object[]> currentSales = receiptsRepository.findDailySalesBetween(startDate, endDate);
 
+        // 이전 주간 데이터 날짜 범위 설정
+        LocalDateTime previousEndDate = startDate.minusDays(1);
+        LocalDateTime previousStartDate = previousEndDate.minusDays(days);
+        List<Object[]> previousSales = receiptsRepository.findDailySalesBetween(previousStartDate, previousEndDate);
+
+        // 날짜 범위 생성 (MM-dd 형식)
+        List<String> currentdateRange = IntStream.rangeClosed(0, (int) (endDate.toLocalDate().toEpochDay() - startDate.toLocalDate().toEpochDay()))
+                .mapToObj(i -> startDate.plusDays(i).format(DateTimeFormatter.ofPattern("MM-dd")))
+                .toList();
+
+        List<String> previousdateRange = IntStream.rangeClosed(0, (int) (previousEndDate.toLocalDate().toEpochDay() - previousStartDate.toLocalDate().toEpochDay()))
+                .mapToObj(i -> previousStartDate.plusDays(i).format(DateTimeFormatter.ofPattern("MM-dd")))
+                .toList();
+
+        // 현재 주간 데이터 맵으로 변환
+        Map<String, BigDecimal> currentSalesMap = currentSales.stream()
+                .collect(Collectors.toMap(
+                        obj -> obj[0].toString(), // 날짜 ("MM-dd")
+                        obj -> (BigDecimal) obj[1]
+                ));
+
+        // 이전 주간 데이터 맵으로 변환
+        Map<String, BigDecimal> previousSalesMap = previousSales.stream()
+                .collect(Collectors.toMap(
+                        obj -> obj[0].toString(), // 날짜 ("MM-dd")
+                        obj -> (BigDecimal) obj[1]
+                ));
+
+        // 현재 주간 데이터 리스트 변환
+        List<Map<String, Object>> formattedCurrentSales = currentdateRange.stream()
+                .map(month -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("date", month);
+                    map.put("revenue", currentSalesMap.getOrDefault(month, BigDecimal.ZERO));
+                    return map;
+                })
+                .toList();
+
+        // 이전 주간 데이터 리스트 변환
+        List<Map<String, Object>> formattedPreviousSales = previousdateRange.stream()
+                .map(month -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("date", month);
+                    map.put("revenue", previousSalesMap.getOrDefault(month, BigDecimal.ZERO));
+                    return map;
+                })
+                .toList();
+
+        return AdminPeriodAnalyticsTO.builder()
+                .current(formattedCurrentSales)
+                .prev(formattedPreviousSales)
+                .build();
+    }
+
+    public AdminPeriodAnalyticsTO getMonthlyAnalytics(int months){
+        LocalDateTime endMonth = LocalDateTime.now();
+        LocalDateTime startMonth = endMonth.minusMonths(months);
+        List<Object[]> currentSales = receiptsRepository.findMonthlySalesBetween(startMonth, endMonth);
+
+        LocalDateTime previousEndMonth = startMonth.minusMonths(1);
+        LocalDateTime previousStartMonth = previousEndMonth.minusMonths(months);
+        List<Object[]> previousSales = receiptsRepository.findMonthlySalesBetween(previousStartMonth, previousEndMonth);
+
+        List<String> currentMonthsRange = IntStream.rangeClosed(0, (int) ChronoUnit.MONTHS.between(startMonth, endMonth))
+                .mapToObj(i -> String.format("%02d월", startMonth.plusMonths(i).getMonthValue()))
+                .toList();
+
+        List<String> previousMonthsRange = IntStream.rangeClosed(0, (int) ChronoUnit.MONTHS.between(previousStartMonth, previousEndMonth))
+                .mapToObj(i -> String.format("%02d월", previousStartMonth.plusMonths(i).getMonthValue()))
+                .toList();
+
+        Map<String, BigDecimal> currentSalesMap = currentSales.stream()
+                .collect(Collectors.toMap(
+                        obj -> String.format("%02d월", Integer.parseInt(obj[0].toString())),
+                        obj -> (BigDecimal) obj[1]
+                ));
+
+        Map<String, BigDecimal> previousSalesMap = previousSales.stream()
+                .collect(Collectors.toMap(
+                        obj -> String.format("%02d월", Integer.parseInt(obj[0].toString())),
+                        obj -> (BigDecimal) obj[1]
+                ));
+
+        List<Map<String, Object>> formattedCurrentSales = currentMonthsRange.stream()
+                .map(month -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("date", month);
+                    map.put("revenue", currentSalesMap.getOrDefault(month, BigDecimal.ZERO));
+                    return map;
+                })
+                .toList();
+
+        List<Map<String, Object>> formattedPreviousSales = previousMonthsRange.stream()
+                .map(month -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("date", month);
+                    map.put("revenue", previousSalesMap.getOrDefault(month, BigDecimal.ZERO));
+                    return map;
+                })
+                .toList();
+
+        return AdminPeriodAnalyticsTO.builder()
+                .current(formattedCurrentSales)
+                .prev(formattedPreviousSales)
+                .build();
+    }
 }

--- a/be/src/main/java/com/project/popupmarket/service/admin/AdminService.java
+++ b/be/src/main/java/com/project/popupmarket/service/admin/AdminService.java
@@ -1,19 +1,32 @@
 package com.project.popupmarket.service.admin;
 
+//import com.project.popupmarket.dto.admin.AdminDashboardTO;
+import com.project.popupmarket.dto.admin.AdminDashboardSummaryTO;
+import com.project.popupmarket.dto.admin.AdminDashboardTO;
+import com.project.popupmarket.dto.admin.AdminMonthlyCountTO;
 import com.project.popupmarket.dto.admin.AdminReceiptsDTO;
 import com.project.popupmarket.dto.land.RentalLandTO;
 import com.project.popupmarket.dto.payment.ReceiptsManageTO;
 import com.project.popupmarket.dto.user.UserDto;
+import com.project.popupmarket.entity.Receipts;
 import com.project.popupmarket.entity.User;
+import com.project.popupmarket.enums.ActivateStatus;
 import com.project.popupmarket.enums.ReservationStatus;
-import com.project.popupmarket.repository.AdminRepository;
-import com.project.popupmarket.repository.UserRepository;
+import com.project.popupmarket.enums.Role;
+import com.project.popupmarket.repository.*;
 import com.project.popupmarket.service.land.RentalLandService;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +35,9 @@ public class AdminService {
     private final UserRepository userRepository;
     private final AdminRepository adminRepository;
     private final RentalLandService rentalLandService;
+    private final ReceiptsRepository receiptsRepository;
+    private final RentalLandJpaRepository rentalLandJpaRepository;
+    private final PopupJpaRepository popupJpaRepository;
 
     public UserDto findReceiptsAdminById(Long userId) {
         ModelMapper modelMapper = new ModelMapper();
@@ -35,7 +51,9 @@ public class AdminService {
                     ReceiptsManageTO receiptsManageTO = ReceiptsManageTO.builder()
                             .paymentKey(receipt.getPaymentKey())
                             .amount(receipt.getAmount())
-                            .reservationStatus(receipt.getReservationStatus())
+                            .start(receipt.getStartDate())
+                            .end(receipt.getEndDate())
+                            .status(receipt.getReservationStatus())
                             .reservedAt(receipt.getReservedAt())
                             .build();
 
@@ -44,4 +62,107 @@ public class AdminService {
                     return new AdminReceiptsDTO(receiptsManageTO, rentalLandTO, user);
                 });
     }
+
+    public AdminDashboardSummaryTO getWeeklyDashboard(){
+
+        List<Object[]> dashboardData = receiptsRepository.findDashboardsBetween(LocalDateTime.now().minusDays(30), LocalDateTime.now());
+        List<AdminDashboardTO> dashboardList = dashboardData.stream()
+                .map(obj -> {
+                    Receipts receipts = (Receipts) obj[0];  // Receipts 엔티티
+                    String customerName = (String) obj[1];  // Popup에서 가져온 customerName
+                    String landlordName = (String) obj[2];  // RentalLand에서 가져온 landlordName
+
+                    ReceiptsManageTO receiptsManageTO = ReceiptsManageTO.builder()
+                            .paymentKey(receipts.getPaymentKey())
+                            .amount(receipts.getAmount())
+                            .start(receipts.getStartDate())
+                            .end(receipts.getEndDate())
+                            .status(receipts.getReservationStatus())
+                            .reservedAt(receipts.getReservedAt())
+                            .build();
+
+                    return new AdminDashboardTO(receiptsManageTO, customerName, landlordName);
+                })
+                .collect(Collectors.toList());
+
+        // 오늘 날짜 가져오기
+        LocalDate today = LocalDate.now();
+
+        // 지난 6일 전 날짜부터 오늘까지의 범위 생성
+        List<LocalDate> lastWeekDates = IntStream.rangeClosed(0, 6)
+                .mapToObj(i -> today.minusDays(6 - i))
+                .toList();
+
+        // 기존 데이터 그룹화
+        Map<LocalDate, Long> transactionMap = dashboardList.stream()
+                .collect(Collectors.groupingBy(
+                        item -> item.getReceipts().getReservedAt().toLocalDate(),
+                        Collectors.counting()
+                ));
+
+        // 모든 날짜를 포함하여 데이터 생성 (없는 날짜는 0)
+        List<Object[]> dailyCounts = lastWeekDates.stream()
+                .map(date -> new Object[]{date.toString(), transactionMap.getOrDefault(date, 0L)})
+                .toList();
+
+
+//        List<Object[]> weeklyRegistered = userRepository.findUsersByRegisteredAtBetween(LocalDateTime.now().minusDays(7),LocalDateTime.now());
+
+        // DB에서 가져온 회원 등록 데이터
+        List<Object[]> weeklyRegistered = userRepository.findUsersByRegisteredAtBetween(
+                LocalDateTime.now().minusDays(7), LocalDateTime.now()
+        );
+
+        // 데이터를 Map<LocalDate, Long> 형태로 변환
+        Map<LocalDate, Long> registeredMap = weeklyRegistered.stream()
+                .collect(Collectors.toMap(
+                        obj -> LocalDate.parse(obj[0].toString()), // 날짜 (String -> LocalDate 변환)
+                        obj -> (Long) obj[1] // 등록된 사용자 수
+                ));
+
+        // 모든 날짜를 포함하여 결과 생성 (없는 날짜는 0)
+        List<Object[]> formattedWeeklyRegistered = lastWeekDates.stream()
+                .map(date -> new Object[]{date.toString(), registeredMap.getOrDefault(date, 0L)})
+                .toList();
+
+
+        Map<Role, Long> countUsersByRoleMap = userRepository.countUsersByRole().stream()
+                .collect(Collectors.toMap(
+                        obj -> (Role) obj[0],
+                        obj -> ((Number) obj[1]).longValue()
+                ));
+
+        Map<ActivateStatus, Long> totalRentalLandsMap = rentalLandJpaRepository.countRentalLandsByStatus().stream()
+                .collect(Collectors.toMap(
+                        obj -> (ActivateStatus) obj[0],
+                        obj -> ((Number) obj[1]).longValue()
+                ));
+
+        Map<ActivateStatus, Long> totalPopupsMap = popupJpaRepository.countPopupsByStatus().stream()
+                .collect(Collectors.toMap(
+                        obj -> (ActivateStatus) obj[0],
+                        obj -> ((Number) obj[1]).longValue()
+                ));
+
+        AdminMonthlyCountTO adminMonthlyCountTO = AdminMonthlyCountTO.builder()
+                .monthlyCount(receiptsRepository.findTotalCountByBetween(LocalDateTime.now().minusMonths(1),LocalDateTime.now()))
+                .monthly(receiptsRepository.findTotalAmountByBetween(LocalDateTime.now().minusMonths(1),LocalDateTime.now()))
+                .weekly(receiptsRepository.findTotalAmountByBetween(LocalDateTime.now().minusWeeks(1),LocalDateTime.now()))
+                .daily(receiptsRepository.findTotalAmountByBetween(LocalDateTime.now().minusDays(1),LocalDateTime.now()))
+                .build();
+
+        AdminDashboardSummaryTO dashboardSummaryTO = AdminDashboardSummaryTO.builder()
+                .dashboardList(dashboardList)
+                .dailyCounts(dailyCounts)
+                .weeklyRegistered(formattedWeeklyRegistered)
+                .countUsersByRole(countUsersByRoleMap)
+                .totalRentalLands(totalRentalLandsMap)
+                .totalPopups(totalPopupsMap)
+                .monthlyCount(adminMonthlyCountTO)
+                .build();
+
+        return dashboardSummaryTO;
+    }
+
+
 }

--- a/be/src/main/java/com/project/popupmarket/service/admin/AdminService.java
+++ b/be/src/main/java/com/project/popupmarket/service/admin/AdminService.java
@@ -65,98 +65,46 @@ public class AdminService {
                 });
     }
 
-    public AdminDashboardSummaryTO getWeeklyDashboard(){
+    public AdminDashboardSummaryTO getWeeklyDashboard() {
+        LocalDateTime startDate = LocalDateTime.now().minusDays(6);
+        LocalDateTime endDate = LocalDateTime.now();
 
-        List<Object[]> dashboardData = receiptsRepository.findDashboardsBetween(LocalDateTime.now().minusDays(6), LocalDateTime.now());
+        // 거래 내역 데이터 조회 및 변환
+        List<Object[]> dashboardData = receiptsRepository.findDashboardsBetween(startDate, endDate);
         List<AdminDashboardTO> dashboardList = dashboardData.stream()
-                .map(obj -> {
-                    Receipts receipts = (Receipts) obj[0];  // Receipts 엔티티
-                    String customerName = (String) obj[1];  // Popup에서 가져온 customerName
-                    String landlordName = (String) obj[2];  // RentalLand에서 가져온 landlordName
-
-                    ReceiptsManageTO receiptsManageTO = ReceiptsManageTO.builder()
-                            .paymentKey(receipts.getPaymentKey())
-                            .amount(receipts.getAmount())
-                            .start(receipts.getStartDate())
-                            .end(receipts.getEndDate())
-                            .status(receipts.getReservationStatus())
-                            .reservedAt(receipts.getReservedAt())
-                            .build();
-
-                    return new AdminDashboardTO(receiptsManageTO, customerName, landlordName);
-                })
-                .collect(Collectors.toList());
-
-        // 오늘 날짜 가져오기
-        LocalDate today = LocalDate.now();
-
-        // 지난 6일 전 날짜부터 오늘까지의 범위 생성
-        List<LocalDate> lastWeekDates = IntStream.rangeClosed(0, 6)
-                .mapToObj(i -> today.minusDays(6 - i))
+                .map(obj -> new AdminDashboardTO(
+                        ReceiptsManageTO.builder()
+                                .paymentKey(((Receipts) obj[0]).getPaymentKey())
+                                .amount(((Receipts) obj[0]).getAmount())
+                                .start(((Receipts) obj[0]).getStartDate())
+                                .end(((Receipts) obj[0]).getEndDate())
+                                .status(((Receipts) obj[0]).getReservationStatus())
+                                .reservedAt(((Receipts) obj[0]).getReservedAt())
+                                .build(),
+                        (String) obj[1],  // Popup 이름
+                        (String) obj[2]   // RentalLand 이름
+                ))
                 .toList();
 
-        // 기존 데이터 그룹화
-        Map<LocalDate, Long> transactionMap = dashboardList.stream()
-                .collect(Collectors.groupingBy(
-                        item -> item.getReceipts().getReservedAt().toLocalDate(),
-                        Collectors.counting()
-                ));
+        // 일일 거래량 데이터
+        List<String> lastWeekDates = generateDateRange(startDate.toLocalDate(), endDate.toLocalDate(), "yyyy-MM-dd", ChronoUnit.DAYS);
+        List<Map<String, Object>> dailyCounts = formatTransactionCounts(dashboardList, lastWeekDates);
 
-        // 모든 날짜를 포함하여 데이터 생성 (없는 날짜는 0)
-        List<Map<String, Object>> dailyCounts = lastWeekDates.stream()
-                .map(date -> {
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("date", date);
-                    map.put("count", transactionMap.getOrDefault(date, 0L));
-                    return map;
-                })
-                .toList();
+        // 일일 가입자 수
+        List<Object[]> weeklyRegistered = userRepository.findUsersByRegisteredAtBetween(startDate, endDate);
+        List<Map<String, Object>> formattedWeeklyRegistered = formatUserRegistrationCounts(weeklyRegistered, lastWeekDates);
 
-        // DB에서 가져온 회원 등록 데이터
-        List<Object[]> weeklyRegistered = userRepository.findUsersByRegisteredAtBetween(
-                LocalDateTime.now().minusDays(6), LocalDateTime.now()
-        );
+        // 통계 데이터
+        Map<Role, Long> countUsersByRoleMap = convertToMap(userRepository.countUsersByRole());
+        Map<ActivateStatus, Long> totalRentalLandsMap = convertToMap(rentalLandJpaRepository.countRentalLandsByStatus());
+        Map<ActivateStatus, Long> totalPopupsMap = convertToMap(popupJpaRepository.countPopupsByStatus());
 
-        // 데이터를 Map<LocalDate, Long> 형태로 변환
-        Map<LocalDate, Long> registeredMap = weeklyRegistered.stream()
-                .collect(Collectors.toMap(
-                        obj -> LocalDate.parse(obj[0].toString()), // 날짜 (String -> LocalDate 변환)
-                        obj -> (Long) obj[1] // 등록된 사용자 수
-                ));
-
-        // 모든 날짜를 포함하여 결과 생성 (없는 날짜는 0)
-        List<Map<String, Object>> formattedWeeklyRegistered = lastWeekDates.stream()
-                .map(date -> {
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("date", date);
-                    map.put("count", registeredMap.getOrDefault(date, 0L));
-                    return map;
-                })
-                .toList();
-
-        Map<Role, Long> countUsersByRoleMap = userRepository.countUsersByRole().stream()
-                .collect(Collectors.toMap(
-                        obj -> (Role) obj[0],
-                        obj -> ((Number) obj[1]).longValue()
-                ));
-
-        Map<ActivateStatus, Long> totalRentalLandsMap = rentalLandJpaRepository.countRentalLandsByStatus().stream()
-                .collect(Collectors.toMap(
-                        obj -> (ActivateStatus) obj[0],
-                        obj -> ((Number) obj[1]).longValue()
-                ));
-
-        Map<ActivateStatus, Long> totalPopupsMap = popupJpaRepository.countPopupsByStatus().stream()
-                .collect(Collectors.toMap(
-                        obj -> (ActivateStatus) obj[0],
-                        obj -> ((Number) obj[1]).longValue()
-                ));
-
+        // 월/주/일 매출 통계
         AdminMonthlyCountTO adminMonthlyCountTO = AdminMonthlyCountTO.builder()
-                .monthlyCount(receiptsRepository.findTotalCountByBetween(LocalDateTime.now().minusMonths(1),LocalDateTime.now()))
-                .monthly(receiptsRepository.findTotalAmountByBetween(LocalDateTime.now().minusMonths(1),LocalDateTime.now()))
-                .weekly(receiptsRepository.findTotalAmountByBetween(LocalDateTime.now().minusWeeks(1),LocalDateTime.now()))
-                .daily(receiptsRepository.findTotalAmountByBetween(LocalDateTime.now().minusDays(1),LocalDateTime.now()))
+                .monthlyCount(receiptsRepository.findTotalCountByBetween(startDate.minusMonths(1), endDate))
+                .monthly(receiptsRepository.findTotalAmountByBetween(startDate.minusMonths(1), endDate))
+                .weekly(receiptsRepository.findTotalAmountByBetween(startDate.minusWeeks(1), endDate))
+                .daily(receiptsRepository.findTotalAmountByBetween(startDate.minusDays(1), endDate))
                 .build();
 
         return AdminDashboardSummaryTO.builder()
@@ -174,55 +122,21 @@ public class AdminService {
         // 현재 주간 데이터 날짜 범위 설정
         LocalDateTime endDate = LocalDateTime.now();
         LocalDateTime startDate = endDate.minusDays(days);
-        List<Object[]> currentSales = receiptsRepository.findDailySalesBetween(startDate, endDate);
 
         // 이전 주간 데이터 날짜 범위 설정
         LocalDateTime previousEndDate = startDate.minusDays(1);
         LocalDateTime previousStartDate = previousEndDate.minusDays(days);
-        List<Object[]> previousSales = receiptsRepository.findDailySalesBetween(previousStartDate, previousEndDate);
 
         // 날짜 범위 생성 (MM-dd 형식)
-        List<String> currentdateRange = IntStream.rangeClosed(0, (int) (endDate.toLocalDate().toEpochDay() - startDate.toLocalDate().toEpochDay()))
-                .mapToObj(i -> startDate.plusDays(i).format(DateTimeFormatter.ofPattern("MM-dd")))
-                .toList();
+        List<String> dateRange = generateDateRange(startDate.toLocalDate(), endDate.toLocalDate(), "MM-dd", ChronoUnit.DAYS);
 
-        List<String> previousdateRange = IntStream.rangeClosed(0, (int) (previousEndDate.toLocalDate().toEpochDay() - previousStartDate.toLocalDate().toEpochDay()))
-                .mapToObj(i -> previousStartDate.plusDays(i).format(DateTimeFormatter.ofPattern("MM-dd")))
-                .toList();
+        // 데이터 맵으로 변환
+        Map<String, BigDecimal> currentSalesMap = convertToMap(receiptsRepository.findDailySalesBetween(startDate, endDate));
+        Map<String, BigDecimal> previousSalesMap = convertToMap(receiptsRepository.findDailySalesBetween(previousStartDate, previousEndDate));
 
-        // 현재 주간 데이터 맵으로 변환
-        Map<String, BigDecimal> currentSalesMap = currentSales.stream()
-                .collect(Collectors.toMap(
-                        obj -> obj[0].toString(), // 날짜 ("MM-dd")
-                        obj -> (BigDecimal) obj[1]
-                ));
-
-        // 이전 주간 데이터 맵으로 변환
-        Map<String, BigDecimal> previousSalesMap = previousSales.stream()
-                .collect(Collectors.toMap(
-                        obj -> obj[0].toString(), // 날짜 ("MM-dd")
-                        obj -> (BigDecimal) obj[1]
-                ));
-
-        // 현재 주간 데이터 리스트 변환
-        List<Map<String, Object>> formattedCurrentSales = currentdateRange.stream()
-                .map(month -> {
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("date", month);
-                    map.put("revenue", currentSalesMap.getOrDefault(month, BigDecimal.ZERO));
-                    return map;
-                })
-                .toList();
-
-        // 이전 주간 데이터 리스트 변환
-        List<Map<String, Object>> formattedPreviousSales = previousdateRange.stream()
-                .map(month -> {
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("date", month);
-                    map.put("revenue", previousSalesMap.getOrDefault(month, BigDecimal.ZERO));
-                    return map;
-                })
-                .toList();
+        // 데이터 리스트 변환
+        List<Map<String, Object>> formattedCurrentSales = formatSalesData(currentSalesMap, dateRange);
+        List<Map<String, Object>> formattedPreviousSales = formatSalesData(previousSalesMap, dateRange);
 
         return AdminPeriodAnalyticsTO.builder()
                 .current(formattedCurrentSales)
@@ -233,53 +147,85 @@ public class AdminService {
     public AdminPeriodAnalyticsTO getMonthlyAnalytics(int months){
         LocalDateTime endMonth = LocalDateTime.now();
         LocalDateTime startMonth = endMonth.minusMonths(months);
-        List<Object[]> currentSales = receiptsRepository.findMonthlySalesBetween(startMonth, endMonth);
 
         LocalDateTime previousEndMonth = startMonth.minusMonths(1);
         LocalDateTime previousStartMonth = previousEndMonth.minusMonths(months);
-        List<Object[]> previousSales = receiptsRepository.findMonthlySalesBetween(previousStartMonth, previousEndMonth);
 
-        List<String> currentMonthsRange = IntStream.rangeClosed(0, (int) ChronoUnit.MONTHS.between(startMonth, endMonth))
-                .mapToObj(i -> String.format("%02d월", startMonth.plusMonths(i).getMonthValue()))
-                .toList();
+        // 날짜 범위 생성 (MM-dd 형식)
+        List<String> monthsRange = generateDateRange(startMonth.toLocalDate(), endMonth.toLocalDate(), "MM", ChronoUnit.MONTHS);
 
-        List<String> previousMonthsRange = IntStream.rangeClosed(0, (int) ChronoUnit.MONTHS.between(previousStartMonth, previousEndMonth))
-                .mapToObj(i -> String.format("%02d월", previousStartMonth.plusMonths(i).getMonthValue()))
-                .toList();
+        // 데이터 맵으로 변환
+        Map<String, BigDecimal> currentSalesMap = convertToMap(receiptsRepository.findMonthlySalesBetween(startMonth, endMonth));
+        Map<String, BigDecimal> previousSalesMap = convertToMap(receiptsRepository.findMonthlySalesBetween(previousStartMonth, previousEndMonth));
 
-        Map<String, BigDecimal> currentSalesMap = currentSales.stream()
-                .collect(Collectors.toMap(
-                        obj -> String.format("%02d월", Integer.parseInt(obj[0].toString())),
-                        obj -> (BigDecimal) obj[1]
-                ));
-
-        Map<String, BigDecimal> previousSalesMap = previousSales.stream()
-                .collect(Collectors.toMap(
-                        obj -> String.format("%02d월", Integer.parseInt(obj[0].toString())),
-                        obj -> (BigDecimal) obj[1]
-                ));
-
-        List<Map<String, Object>> formattedCurrentSales = currentMonthsRange.stream()
-                .map(month -> {
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("date", month);
-                    map.put("revenue", currentSalesMap.getOrDefault(month, BigDecimal.ZERO));
-                    return map;
-                })
-                .toList();
-
-        List<Map<String, Object>> formattedPreviousSales = previousMonthsRange.stream()
-                .map(month -> {
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("date", month);
-                    map.put("revenue", previousSalesMap.getOrDefault(month, BigDecimal.ZERO));
-                    return map;
-                })
-                .toList();
+        // 데이터 리스트 변환
+        List<Map<String, Object>> formattedCurrentSales = formatSalesData(currentSalesMap, monthsRange);
+        List<Map<String, Object>> formattedPreviousSales = formatSalesData(previousSalesMap, monthsRange);
 
         return AdminPeriodAnalyticsTO.builder()
                 .current(formattedCurrentSales)
                 .prev(formattedPreviousSales)
                 .build();
+    }
+
+    /** 날짜 범위 리스트 생성 */
+    private List<String> generateDateRange(LocalDate start, LocalDate end, String pattern, ChronoUnit unit) {
+        return IntStream.rangeClosed(0, (int) unit.between(start, end))
+                .mapToObj(i -> start.plus(i, unit).format(DateTimeFormatter.ofPattern(pattern)))
+                .toList();
+    }
+
+    /** 매출 데이터 변환 */
+    private List<Map<String, Object>> formatSalesData(Map<String, BigDecimal> salesMap, List<String> dateRange) {
+        return dateRange.stream()
+                .map(date -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("date", date);
+                    map.put("revenue", salesMap.getOrDefault(date, BigDecimal.ZERO));
+                    return map;
+                })
+//                .map(date -> Map.of("date", date, "revenue", salesMap.getOrDefault(date, BigDecimal.ZERO)))
+                .toList();
+    }
+
+    /** 거래량 데이터 변환 */
+    private List<Map<String, Object>> formatTransactionCounts(List<AdminDashboardTO> transactions, List<String> dateRange) {
+        Map<String, Long> transactionMap = transactions.stream()
+                .collect(Collectors.groupingBy(item -> item.getReceipts().getReservedAt().toLocalDate().toString(), Collectors.counting()));
+
+        return dateRange.stream()
+                .map(date -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("date", date);
+                    map.put("count", transactionMap.getOrDefault(date, 0L));
+                    return map;
+                })
+//                .map(date -> Map.of("date", date, "count", transactionMap.getOrDefault(date, 0L)))
+                .toList();
+    }
+
+    /** 사용자 가입 데이터 변환 */
+    private List<Map<String, Object>> formatUserRegistrationCounts(List<Object[]> rawData, List<String> dateRange) {
+        Map<String, Long> registrationMap = rawData.stream()
+                .collect(Collectors.toMap(obj -> obj[0].toString(), obj -> (Long) obj[1]));
+
+        return dateRange.stream()
+                .map(date -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("date", date);
+                    map.put("count", registrationMap.getOrDefault(date, 0L));
+                    return map;
+                })
+//                .map(date -> Map.of("date", date, "count", registrationMap.getOrDefault(date, 0L)))
+                .toList();
+    }
+
+    /** 데이터 변환 (Role & ActivateStatus) */
+    private <K, V> Map<K, V> convertToMap(List<Object[]> rawData) {
+        return rawData.stream().collect(
+                Collectors.toMap(
+                        obj -> (K) obj[0],
+                        obj -> (V) obj[1]
+                ));
     }
 }

--- a/be/src/main/java/com/project/popupmarket/service/admin/AdminService.java
+++ b/be/src/main/java/com/project/popupmarket/service/admin/AdminService.java
@@ -23,10 +23,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -141,6 +138,7 @@ public class AdminService {
         return AdminPeriodAnalyticsTO.builder()
                 .current(formattedCurrentSales)
                 .prev(formattedPreviousSales)
+                .data(getRevenueByRegion(startDate, endDate))
                 .build();
     }
 
@@ -165,7 +163,47 @@ public class AdminService {
         return AdminPeriodAnalyticsTO.builder()
                 .current(formattedCurrentSales)
                 .prev(formattedPreviousSales)
+                .data(getRevenueByRegion(startMonth, endMonth))
                 .build();
+    }
+
+    private static final Map<String, String> REGION_MAPPING = Map.ofEntries(
+            Map.entry("서울", "서울"), Map.entry("부산", "부산"), Map.entry("대구", "대구"), Map.entry("인천", "인천"),
+            Map.entry("광주", "광주"), Map.entry("대전", "대전"), Map.entry("울산", "울산"), Map.entry("세종", "세종"),
+            Map.entry("경기", "경기"), Map.entry("충북", "충북"), Map.entry("충남", "충남"), Map.entry("전북", "전북"),
+            Map.entry("전남", "전남"), Map.entry("경북", "경북"), Map.entry("경남", "경남"), Map.entry("강원", "강원"),
+            Map.entry("제주", "제주")
+    );
+
+//    public List<Map<String, Object>> getRevenueByRegion(LocalDateTime startDate, LocalDateTime endDate) {
+    public AdminDataAnalyticsTO getRevenueByRegion(LocalDateTime startDate, LocalDateTime endDate) {
+
+        List<Object[]> rawData = receiptsRepository.findRevenueByAddress(startDate, endDate);
+
+        Map<String, Long> revenueByRegion = rawData.stream()
+                .collect(Collectors.groupingBy(obj -> {
+                    String address = obj[0].toString();
+                    return REGION_MAPPING.entrySet().stream()
+                            .filter(entry -> address.startsWith(entry.getKey()))
+                            .map(Map.Entry::getValue)
+                            .findFirst()
+                            .orElse("기타");
+                }, Collectors.summingLong(obj -> ((BigDecimal) obj[1]).longValue())));
+
+        List<String> labels = new ArrayList<>(revenueByRegion.keySet());
+
+        List<Long> data = labels.stream()
+                .map(revenueByRegion::get)
+                .collect(Collectors.toList());
+
+        return AdminDataAnalyticsTO.builder()
+                .labels(labels)
+                .data(data)
+                .build();
+
+    }
+    public void getCategoryAnalytics(){
+
     }
 
     /** 날짜 범위 리스트 생성 */

--- a/be/src/main/java/com/project/popupmarket/service/popup/PopupService.kt
+++ b/be/src/main/java/com/project/popupmarket/service/popup/PopupService.kt
@@ -1,5 +1,6 @@
 package com.project.popupmarket.service.popup
 
+import com.project.popupmarket.dto.land.RentalLandTO
 import com.project.popupmarket.dto.popup.PopupRespTO
 import com.project.popupmarket.dto.popup.PopupTO
 import com.project.popupmarket.entity.Popup
@@ -123,6 +124,29 @@ open class PopupService(
             throw ResourceNotFoundException("팝업에 대한 데이터가 없습니다.")
         }
         return popupRespTO
+    }
+
+    // 2 - 5. Read : 관리자 페이지 조건에 해당하는 팝업 20개 조회 + 검색 포함
+    // TODO : 추후 Admin Migration 완료 이후에 'AdminService' 로 이동
+    fun findPopupAdminByFilter(
+        address: String?, status: ActivateStatus?,
+        title: String?, type: String?,
+        sorting: String?, pageable: Pageable?
+    ): Page<PopupTO> {
+        val modelMapper = ModelMapper()
+        println(popupJpaRepository.findPopupAdminByFilter(
+            address, status, title, type, sorting, pageable // title 파라미터 추가
+        ))
+
+        // 필터링된 데이터를 가져옴
+        val popupPage = popupJpaRepository.findPopupAdminByFilter(
+            address, status, title, type, sorting, pageable // title 파라미터 추가
+        ).map { popup ->
+            modelMapper.map(popup, PopupTO::class.java)
+        }
+
+        // 데이터를 매핑하여 반환
+        return popupPage
     }
 
     // POST Popup


### PR DESCRIPTION
feat: Admin API 필터링 및 대시보드 통계 기능 추가

### 1. Admin API 필터링 기능 추가
- 임대지 리스트 (`/lands`), 거래내역 (`/receipts`), 팝업 리스트 (`/popups`) 필터링 기능 구현
  - 주소, 상태, 제목, 유형, 정렬(sorting), 페이지네이션(pageable) 적용
  - AdminController에서 필터링 조건을 활용한 조회 API 추가

### 2. Admin 대시보드 (`/dashboard`), 매출 통계 (`/analytics`) 기능 추가
- Admin 대시보드 `getWeeklyDashboard()` 메서드 추가
  - 최근 7일간 거래 내역 조회 및 매핑
  - 일일 거래량 (`dailyCounts`), 회원 가입 통계 (`weeklyRegistered`) 포함
  - 역할별 사용자 수, 상태별 임대지 및 팝업 현황 통계 조회

- 매출 통계 분석 `getDailyAnalytics()`, `getMonthlyAnalytics()` 메서드 추가
  - 최근 `N`일간 / `N`개월간 매출과 이전 매출을 비교

### 3. 공통 로직 리팩토링
- 날짜 범위 생성 (`generateDateRange()`) 및 데이터 변환 메서드 (`formatSalesData()`, `convertToMap()`) 추가
- 중복된 데이터 처리를 제거하여 메서드로 분리
